### PR TITLE
check `Return` sections in docstrings - remove unambiguous names

### DIFF
--- a/core/stats.py
+++ b/core/stats.py
@@ -25,7 +25,7 @@ def add_node_degree(
 
     Returns
     -------
-    node_gdf : geopandas.GeoDataFrame
+    geopandas.GeoDataFrame
         Updated node data.
     """
     node_gdf["degree"] = node_gdf["nodeID"].map(lambda x: networkx.degree(graph, x))


### PR DESCRIPTION
* This PR resolves #84
* actually only affected 1 function
* basic rules:
  * if a tuple or multiple returns through logic, keep names
  * otherwise remove name in docstring
* ***failures are unrelated to this PR*** 