### PR TITLE
Collapse new nodes

### DIFF
--- a/core/algorithms/artifacts.py
+++ b/core/algorithms/artifacts.py
@@ -1022,6 +1022,10 @@ def nx_gx_cluster(
     else:
         # a loop that has only a single entry point - use individual segments
         merged_edges = edges_on_boundary.dissolve().line_merge().item()
+        if merged_edges.geom_type != "LineString":
+            # this is a fallback for corner cases. It should result in the nearly the
+            # same skeleton in the end but ensures we work with a single-part geometry
+            merged_edges = shapely.concave_hull(merged_edges).exterior
         skeletonization_input = list(
             map(
                 shapely.LineString,

--- a/core/algorithms/artifacts.py
+++ b/core/algorithms/artifacts.py
@@ -297,6 +297,7 @@ def one_remaining(
     max_segment_length,
     split_points,
     limit_distance,
+    consolidation_tolerance,
 ):
     # find the nearest relevant target
     remaining_nearest, target_nearest = relevant_targets.sindex.nearest(
@@ -320,6 +321,7 @@ def one_remaining(
             max_segment_length=max_segment_length,
             buffer=limit_distance,  # TODO: figure out if we need this
             limit_distance=limit_distance,
+            consolidation_tolerance=consolidation_tolerance,
         )
         split_points.extend(splitters)
 
@@ -335,6 +337,7 @@ def multiple_remaining(
     split_points,
     snap_to,
     limit_distance,
+    consolidation_tolerance,
 ):
     # use skeleton to ensure all nodes are naturally connected
     new_connections, splitters = voronoi_skeleton(
@@ -345,6 +348,7 @@ def multiple_remaining(
         secondary_snap_to=highest_hierarchy.geometry,
         limit_distance=limit_distance,
         # buffer = highest_hierarchy.length.sum() * 1.2
+        consolidation_tolerance=consolidation_tolerance,
     )
     split_points.extend(splitters)
 
@@ -360,6 +364,7 @@ def one_remaining_c(
     max_segment_length,
     split_points,
     limit_distance,
+    consolidation_tolerance,
 ):
     # create a new connection as the shortest straight line to any C
     new_connections = shapely.shortest_line(
@@ -380,6 +385,7 @@ def one_remaining_c(
             max_segment_length=max_segment_length,
             limit_distance=limit_distance,
             # buffer = highest_hierarchy.length.sum() * 1.2
+            consolidation_tolerance=consolidation_tolerance,
         )
     split_points.extend(splitters)
 
@@ -426,6 +432,7 @@ def loop(
         max_segment_length=max_segment_length,
         limit_distance=limit_distance,
         # buffer = highest_hierarchy.length.sum() * 1.2
+        consolidation_tolerance=0,
     )
     split_points.extend(splitters)
 
@@ -563,6 +570,7 @@ def nx_gx_identical(
     angle,
     max_segment_length=1,
     limit_distance=2,
+    consolidation_tolerance=10,
     eps=1e-4,
 ):
     """If there are  1+ identical continuity groups, and more than 1 node (n>=2)
@@ -598,6 +606,7 @@ def nx_gx_identical(
             max_segment_length=max_segment_length,
             limit_distance=limit_distance,
             snap_to=relevant_nodes,
+            consolidation_tolerance=consolidation_tolerance,
         )
         to_add.extend(weld_edges(lines, ignore=relevant_nodes.geometry))
     # if the angle between two lines is too sharp, replace with a direct connection
@@ -627,6 +636,7 @@ def nx_gx(
     max_segment_length=1,
     limit_distance=2,
     min_dangle_length=10,
+    consolidation_tolerance=10,
     eps=1e-4,
 ):
     """
@@ -748,6 +758,7 @@ def nx_gx(
                     max_segment_length=max_segment_length,
                     limit_distance=limit_distance,
                     # buffer = highest_hierarchy.length.sum() * 1.2
+                    consolidation_tolerance=consolidation_tolerance,
                 )
 
                 # if there are multiple components, limit_distance was too drastic and
@@ -767,6 +778,7 @@ def nx_gx(
                         max_segment_length=max_segment_length,
                         limit_distance=eps,
                         # buffer = highest_hierarchy.length.sum() * 1.2
+                        consolidation_tolerance=consolidation_tolerance,
                     )
                 split_points.extend(splitters)
 
@@ -824,6 +836,7 @@ def nx_gx(
                     max_segment_length,
                     split_points,
                     limit_distance,
+                    consolidation_tolerance,
                 )
 
             # SUB BRANCH - more than one remaining node
@@ -840,6 +853,7 @@ def nx_gx(
                     split_points,
                     relevant_targets.geometry,
                     limit_distance,
+                    consolidation_tolerance,
                 )
 
         # BRANCH 3 - no target nodes - snapping to C
@@ -860,6 +874,7 @@ def nx_gx(
                     max_segment_length,
                     split_points,
                     limit_distance,
+                    consolidation_tolerance,
                 )
 
             # SUB BRANCH - more than one remaining node
@@ -876,6 +891,7 @@ def nx_gx(
                     split_points,
                     highest_hierarchy.dissolve("coins_group").geometry,
                     limit_distance,
+                    consolidation_tolerance,
                 )
 
             new_connections = reconnect(
@@ -943,6 +959,7 @@ def nx_gx_cluster(
     to_add,
     max_segment_length=1,
     min_dangle_length=20,
+    consolidation_tolerance=10,
     eps=1e-4,
 ):
     """treat an n-artifact cluster: merge all artifact polygons; drop
@@ -1017,6 +1034,7 @@ def nx_gx_cluster(
         snap_to=False,
         max_segment_length=max_segment_length,
         limit_distance=1e-4,
+        consolidation_tolerance=consolidation_tolerance,
     )
 
     # if we used only segments, we need to remove dangles

--- a/core/algorithms/artifacts.py
+++ b/core/algorithms/artifacts.py
@@ -970,10 +970,12 @@ def nx_gx_cluster(
         edges.sindex.query(cluster_geom.buffer(eps), predicate="contains")
     ].index.to_list()
     connection = edges.drop(lines_to_drop).geometry
+    # non-planar lines are not connections
+    connection = connection[~connection.crosses(cluster_geom)]
 
     # if there's nothing to drop due to planarity, there's nothing to replace and
     # we can stop here
-    if not lines_to_drop:
+    if not lines_to_drop or connection.empty:
         return
 
     # get edges on boundary

--- a/core/algorithms/simplify.py
+++ b/core/algorithms/simplify.py
@@ -30,6 +30,7 @@ def simplify_singletons(
     eps=1e-4,
     limit_distance=2,
     simplification_factor=2,
+    consolidation_tolerance=10,
 ):
     # Get nodes from the network.
     nodes = momepy.nx_to_gdf(momepy.node_degree(momepy.gdf_to_nx(roads)), lines=False)
@@ -110,6 +111,7 @@ def simplify_singletons(
                 angle=75,
                 max_segment_length=max_segment_length,
                 limit_distance=limit_distance,
+                consolidation_tolerance=consolidation_tolerance,
             )
 
         elif (artifact.node_count > 1) and (len(artifact.ces_type) > 2):
@@ -124,6 +126,7 @@ def simplify_singletons(
                 max_segment_length=max_segment_length,
                 limit_distance=limit_distance,
                 min_dangle_length=min_dangle_length,
+                consolidation_tolerance=consolidation_tolerance,
             )
         else:
             logger.debug("NON PLANAR")
@@ -159,6 +162,7 @@ def simplify_clusters(
     eps=1e-4,
     simplification_factor=2,
     min_dangle_length=20,
+    consolidation_tolerance=10,
 ):
     # Get nodes from the network.
     nodes = momepy.nx_to_gdf(momepy.node_degree(momepy.gdf_to_nx(roads)), lines=False)
@@ -184,6 +188,7 @@ def simplify_clusters(
             eps=eps,
             max_segment_length=max_segment_length,
             min_dangle_length=min_dangle_length,
+            consolidation_tolerance=consolidation_tolerance,
         )
 
     cleaned_roads = roads.drop(to_drop)
@@ -216,6 +221,7 @@ def simplify_pairs(
     min_dangle_length=20,
     limit_distance=2,
     simplification_factor=2,
+    consolidation_tolerance=10,
 ):
     # Get nodes from the network.
     nodes = momepy.nx_to_gdf(momepy.node_degree(momepy.gdf_to_nx(roads)), lines=False)
@@ -324,6 +330,7 @@ def simplify_pairs(
             compute_coins=False,
             min_dangle_length=min_dangle_length,
             simplification_factor=simplification_factor,
+            consolidation_tolerance=consolidation_tolerance,
         )
         if not second.empty:
             roads_cleaned = simplify_singletons(
@@ -334,6 +341,7 @@ def simplify_pairs(
                 compute_coins=True,
                 min_dangle_length=min_dangle_length,
                 simplification_factor=simplification_factor,
+                consolidation_tolerance=consolidation_tolerance,
             )
     if not for_skeleton.empty:
         roads_cleaned = simplify_clusters(
@@ -342,6 +350,7 @@ def simplify_pairs(
             max_segment_length=max_segment_length,
             simplification_factor=simplification_factor,
             min_dangle_length=min_dangle_length,
+            consolidation_tolerance=consolidation_tolerance,
         )
     return roads_cleaned
 

--- a/core/algorithms/simplify.py
+++ b/core/algorithms/simplify.py
@@ -421,6 +421,7 @@ def simplify_network(
     min_dangle_length=20,
     limit_distance=2,
     simplification_factor=2,
+    consolidation_tolerance=10,
     area_threshold_blocks=1e5,
     isoareal_threshold_blocks=0.5,
     area_threshold_circles=5e4,
@@ -447,6 +448,7 @@ def simplify_network(
         min_dangle_length=min_dangle_length,
         limit_distance=limit_distance,
         simplification_factor=simplification_factor,
+        consolidation_tolerance=consolidation_tolerance,
         eps=eps,
     )
 
@@ -468,6 +470,7 @@ def simplify_network(
         min_dangle_length=min_dangle_length,
         limit_distance=limit_distance,
         simplification_factor=simplification_factor,
+        consolidation_tolerance=consolidation_tolerance,
         eps=eps,
     )
 
@@ -481,6 +484,7 @@ def simplify_loop(
     min_dangle_length=20,
     limit_distance=2,
     simplification_factor=2,
+    consolidation_tolerance=10,
     eps=1e-4,
 ):
     # Remove edges fully within the artifact (dangles).
@@ -508,6 +512,7 @@ def simplify_loop(
             roads,
             max_segment_length=max_segment_length,
             simplification_factor=simplification_factor,
+            consolidation_tolerance=consolidation_tolerance,
         )
     if not doubles.empty:
         roads = simplify_pairs(
@@ -517,6 +522,7 @@ def simplify_loop(
             min_dangle_length=min_dangle_length,
             limit_distance=limit_distance,
             simplification_factor=simplification_factor,
+            consolidation_tolerance=consolidation_tolerance,
         )
     if not clusters.empty:
         roads = simplify_clusters(
@@ -526,6 +532,7 @@ def simplify_loop(
             simplification_factor=simplification_factor,
             eps=eps,
             min_dangle_length=min_dangle_length,
+            consolidation_tolerance=consolidation_tolerance,
         )
 
     return roads


### PR DESCRIPTION
This allows for collapsing of nearby nodes within the newly generated geometry. It ensures that Voronoi-based nodes that look like a single node are collapsed to actual single node.

It is a bit tricky to get the tolerance right and consolidation still works within the whole dbscan cluster rather than iteratively, but it works okay for our use cases.

the consolidation algo tends to fail with larger tolerances on whole networks as the difference call in there occasionally produces MultiLineString but that is for future someone to resolve.

This is all enabled by a change of consolidation algo that can now preserve location of dead-end nodes, which is what we need within the Voronoi to ensure proper re-connection to the rest of the network.