### PR TITLE
include exclusion_mask

### DIFF
--- a/core/algorithms/artifacts.py
+++ b/core/algorithms/artifacts.py
@@ -29,6 +29,8 @@ def get_artifacts(
     isoareal_threshold_blocks=0.5,
     area_threshold_circles=5e4,
     isoareal_threshold_circles=0.75,
+    exclusion_mask=None,
+    predicate="intersects",
 ):
     with warnings.catch_warnings():  # the second loop likey won't find threshold
         warnings.filterwarnings("ignore", message="No threshold found")
@@ -93,8 +95,13 @@ def get_artifacts(
         if artifact_count_after == artifact_count_before:
             break
 
-    artifacts = polygons[polygons.is_artifact][["geometry"]].copy()
+    artifacts = polygons[polygons.is_artifact][["geometry"]].reset_index(drop=True)
     artifacts["id"] = artifacts.index
+
+    if exclusion_mask is not None:
+        _, art_idx = artifacts.sindex.query(exclusion_mask, predicate=predicate)
+        artifacts = artifacts.drop(np.unique(art_idx)).copy()
+
     return artifacts, threshold
 
 

--- a/core/algorithms/simplify.py
+++ b/core/algorithms/simplify.py
@@ -427,6 +427,8 @@ def simplify_network(
     area_threshold_circles=5e4,
     isoareal_threshold_circles=0.75,
     eps=1e-4,
+    exclusion_mask=None,
+    predicate="intersects",
 ):
     # Merge nearby nodes (up to double of distance used in skeleton).
     roads = consolidate_nodes(roads, tolerance=max_segment_length * 2.1)
@@ -438,6 +440,8 @@ def simplify_network(
         isoareal_threshold_blocks=isoareal_threshold_blocks,
         area_threshold_circles=area_threshold_circles,
         isoareal_threshold_circles=isoareal_threshold_circles,
+        exclusion_mask=exclusion_mask,
+        predicate=predicate,
     )
 
     # Loop 1
@@ -460,6 +464,8 @@ def simplify_network(
         isoareal_threshold_blocks=isoareal_threshold_blocks,
         area_threshold_circles=area_threshold_circles,
         isoareal_threshold_circles=isoareal_threshold_circles,
+        exclusion_mask=exclusion_mask,
+        predicate=predicate,
     )
 
     # Loop 2


### PR DESCRIPTION
This adds the option to pass an exclusion mask (do you have an idea for a better name?) containing geometries which presence excludes an artifact from simplification. If there's a building in an artifact, don't touch it. Same with water etc.