### PR TITLE
keep only connections that are inside the artifact when reconnecting non-planar to clusters

### DIFF
--- a/core/algorithms/artifacts.py
+++ b/core/algorithms/artifacts.py
@@ -1081,6 +1081,17 @@ def nx_gx_cluster(
     # those edges_kept.endpoints and
     non_planar_connections = shapely.shortest_line(skel_nodes, to_reconnect)
 
+    # keep only those that are within
+    conn_within = is_within(non_planar_connections, cluster_geom)
+    if not all(conn_within):
+        warnings.warn(
+            "Could not create a connection as it would lead outside "
+            "of the artifact.",
+            UserWarning,
+            stacklevel=2,
+        )
+    non_planar_connections = non_planar_connections[conn_within]
+
     ### extend our list "to_add" with this artifact clusters' contribution:
     lines_to_add.extend(non_planar_connections)
     to_add.extend(lines_to_add)


### PR DESCRIPTION
I've only noticed a change in this case, where the weird line is no longer there. But it may cause some disconnections in the network. I am not sure how to get a better connection in those cases though.

<img width="823" alt="Screenshot 2024-08-21 at 09 48 27" src="https://github.com/user-attachments/assets/73d28f87-8376-41c6-b5a4-c8c089ef1305">
