### PR TITLE
update notebooks to use sgeop

### DIFF
--- a/notebooks/simplification_api.ipynb
+++ b/notebooks/simplification_api.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -19,8 +19,9 @@
     "import warnings\n",
     "\n",
     "import folium\n",
+    "import sgeop\n",
     "\n",
-    "from core import algorithms, utils\n"
+    "from core import utils\n"
    ]
   },
   {
@@ -32,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,12 +53,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# # Get the logger for core.algorithms.simplify\n",
-    "# logger = logging.getLogger('core.algorithms.simplify')\n",
+    "# # Get the logger for sgeop.simplify\n",
+    "# logger = logging.getLogger('sgeop.simplify')\n",
     "# logger.setLevel(logging.DEBUG)\n",
     "\n",
     "# # Set the logging format\n",
@@ -81,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,11 +114,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_roads = algorithms.simplify.simplify_network(roads)"
+    "new_roads = sgeop.simplify_network(roads)"
    ]
   },
   {
@@ -138,6 +139,13 @@
     "folium.LayerControl().add_to(m)\n",
     "m"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/simplification_pipeline.ipynb
+++ b/notebooks/simplification_pipeline.ipynb
@@ -24,8 +24,9 @@
     "\n",
     "import folium\n",
     "from libpysal import graph\n",
+    "import sgeop\n",
     "\n",
-    "from core import algorithms, utils\n"
+    "from core import utils\n"
    ]
   },
   {
@@ -122,7 +123,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "roads = algorithms.simplify.consolidate_nodes(roads, tolerance=2.1)"
+    "roads = sgeop.consolidate_nodes(roads, tolerance=2.1)"
    ]
   },
   {
@@ -138,7 +139,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifacts, _ = algorithms.simplify.get_artifacts(roads)"
+    "artifacts, _ = sgeop.get_artifacts(roads)"
    ]
   },
   {
@@ -156,7 +157,7 @@
    "source": [
     "_, r_idx = roads.sindex.query(artifacts.geometry, predicate=\"contains\")\n",
     "roads = roads.drop(roads.index[r_idx])\n",
-    "roads = algorithms.simplify.remove_false_nodes(roads)"
+    "roads = sgeop.remove_false_nodes(roads)"
    ]
   },
   {
@@ -228,57 +229,59 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/martin/Git/simplification/core/geometry.py:189: UserWarning: Could not create a connection as it would lead outside of the artifact.\n",
+      "/home/martin/Git/sgeop/sgeop/geometry.py:227: UserWarning: Could not create a connection as it would lead outside of the artifact.\n",
       "  additions, splits = snap_to_targets(\n",
-      "/Users/martin/miniforge3/envs/simplification/lib/python3.11/site-packages/geopandas/geodataframe.py:1819: SettingWithCopyWarning: \n",
+      "/home/martin/mambaforge/envs/simplification/lib/python3.11/site-packages/geopandas/geodataframe.py:1819: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
       "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
       "  super().__setitem__(key, value)\n",
-      "/Users/martin/miniforge3/envs/simplification/lib/python3.11/site-packages/geopandas/geodataframe.py:1819: SettingWithCopyWarning: \n",
+      "/home/martin/mambaforge/envs/simplification/lib/python3.11/site-packages/geopandas/geodataframe.py:1819: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
       "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
       "  super().__setitem__(key, value)\n",
-      "/Users/martin/miniforge3/envs/simplification/lib/python3.11/site-packages/geopandas/geodataframe.py:1819: SettingWithCopyWarning: \n",
+      "/home/martin/mambaforge/envs/simplification/lib/python3.11/site-packages/geopandas/geodataframe.py:1819: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
       "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
       "  super().__setitem__(key, value)\n",
-      "/Users/martin/miniforge3/envs/simplification/lib/python3.11/site-packages/geopandas/geodataframe.py:1819: SettingWithCopyWarning: \n",
+      "/home/martin/mambaforge/envs/simplification/lib/python3.11/site-packages/geopandas/geodataframe.py:1819: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
       "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
       "  super().__setitem__(key, value)\n",
-      "/Users/martin/miniforge3/envs/simplification/lib/python3.11/site-packages/geopandas/geodataframe.py:1819: SettingWithCopyWarning: \n",
+      "/home/martin/mambaforge/envs/simplification/lib/python3.11/site-packages/geopandas/geodataframe.py:1819: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
       "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
       "  super().__setitem__(key, value)\n",
-      "/Users/martin/miniforge3/envs/simplification/lib/python3.11/site-packages/geopandas/geodataframe.py:1819: SettingWithCopyWarning: \n",
+      "/home/martin/mambaforge/envs/simplification/lib/python3.11/site-packages/geopandas/geodataframe.py:1819: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
       "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
       "  super().__setitem__(key, value)\n",
-      "/Users/martin/miniforge3/envs/simplification/lib/python3.11/site-packages/geopandas/geodataframe.py:1819: SettingWithCopyWarning: \n",
+      "/home/martin/mambaforge/envs/simplification/lib/python3.11/site-packages/geopandas/geodataframe.py:1819: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
       "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "  super().__setitem__(key, value)\n"
+      "  super().__setitem__(key, value)\n",
+      "/home/martin/Git/sgeop/sgeop/simplify.py:200: UserWarning: Could not create a connection as it would lead outside of the artifact.\n",
+      "  nx_gx_cluster(\n"
      ]
     }
    ],
    "source": [
-    "new_roads = algorithms.simplify.simplify_singletons(singles, roads)\n",
-    "new_roads = algorithms.simplify.simplify_pairs(doubles, new_roads)\n",
-    "new_roads = algorithms.simplify.simplify_clusters(clusters, new_roads)"
+    "new_roads = sgeop.simplify.simplify_singletons(singles, roads)\n",
+    "new_roads = sgeop.simplify.simplify_pairs(doubles, new_roads)\n",
+    "new_roads = sgeop.simplify.simplify_clusters(clusters, new_roads)"
    ]
   },
   {

--- a/notebooks/simplification_pipeline.ipynb
+++ b/notebooks/simplification_pipeline.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "To deal with some minor consequences of simplification, we will need to run this twice, in some way.\n",
     "\n",
-    "Also, it should be combined togehter to a single function that does not call `simplify_singletons`, `simplify_pairs`, and `simplify_clusters` in a sequence like this as there's some duplicated computation hapenning. But it works. Mostly."
+    "Also, it should be combined together to a single function that does not call `simplify_singletons`, `simplify_pairs`, and `simplify_clusters` in a sequence like this as there's some duplicated computation happening. But it works. Mostly."
    ]
   },
   {

--- a/notebooks/simplification_prg.ipynb
+++ b/notebooks/simplification_prg.ipynb
@@ -15,18 +15,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import logging\n",
     "import warnings\n",
     "\n",
     "import folium\n",
-    "import momepy\n",
     "import geopandas\n",
-    "\n",
-    "from core import algorithms, utils\n",
-    "\n",
-    "\n",
-    "import numpy as np\n",
-    "from scipy import sparse"
+    "import sgeop"
    ]
   },
   {
@@ -71,7 +64,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "roads = algorithms.nodes.fix_topology(roads)"
+    "roads = sgeop.fix_topology(roads)"
    ]
   },
   {
@@ -112,7 +105,7 @@
     }
    ],
    "source": [
-    "new_roads = algorithms.simplify.simplify_network(roads, exclusion_mask=buildings.geometry)"
+    "new_roads = sgeop.simplify_network(roads, exclusion_mask=buildings.geometry)"
    ]
   },
   {


### PR DESCRIPTION
This updates the main top level notebooks to use functions from the `sgeop` package where the main simplification algos live now.

We should probably try to organise the notebooks folder a bit to indicate what is up to date and what has been used in progress but is no longer relevant.